### PR TITLE
Remove Typekit

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <title>thoughtbot Brand Assets & Guidelines</title>
     <link href="stylesheets/base.css" rel="stylesheet" type="text/css" />
-    <script src="//use.typekit.net/gnk7llu.js"></script>
-    <script>try{Typekit.load();}catch(e){}</script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
   </head>
   <body class="index">


### PR DESCRIPTION
We are not using the fonts that Typekit is injecting (Calluna Sans and
Freight Text Pro).

We stopped using them in
https://github.com/thoughtbot/presskit/commit/d142411913d678795ba853d8d51b6fc8947150fa#diff-2605eafe177eaedc808ae364fe54abafL6