### PR TITLE
Configure CircleCI to run htmlproofer against generated pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.4.3-node
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: presskit-{{ arch }}-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Install Ruby dependencies
+          command: bundle install --path vendor/bundle
+
+      - save_cache:
+          key: presskit-{{ arch }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+      - run:
+          name: Build Middleman site
+          command: bin/build
+
+      - run:
+          name: Run HTMLProofer
+          command: bin/test

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ gem "bourbon"
 gem "middleman"
 gem "middleman-autoprefixer"
 gem "middleman-minify-html"
+
+group :development, :test do
+  gem "html-proofer"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,10 +18,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    colorize (0.8.1)
     concurrent-ruby (1.1.5)
     contracts (0.13.0)
     dotenv (2.7.1)
     erubis (2.7.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.1.5)
@@ -32,6 +35,15 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashie (3.6.0)
+    html-proofer (3.10.2)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.9)
+      parallel (~> 1.3)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     htmlcompressor (0.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -40,6 +52,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
+    mercenary (0.3.6)
     middleman (4.3.3)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
@@ -77,7 +90,10 @@ GEM
     middleman-minify-html (3.4.1)
       htmlcompressor (~> 0.2.0)
       middleman-core (>= 3.2)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.4)
@@ -104,16 +120,20 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bourbon
+  html-proofer
   middleman
   middleman-autoprefixer
   middleman-minify-html

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# bin/build: Generate the middleman site
+
+set -e
+
+bundle exec middleman build --verbose

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# bin/test: Run the htmlproofer suite
+
+set -e
+
+bundle exec htmlproofer ./build --check-html --check-favicon --disable-external

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>thoughtbot Brand Assets & Guidelines</title>
+    <link type="image/ico" href="/favicon.ico" rel="icon">
     <%= stylesheet_link_tag "base" %>
   </head>
   <body>


### PR DESCRIPTION
Borrowing this setup from the apprentice website.

While pushing the branch to test, I noticed that it caught an issue (missing favicon ref), so I added that.