### PR TITLE
Add functionality to download the brand guide

### DIFF
--- a/source/assets/stylesheets/_main.scss
+++ b/source/assets/stylesheets/_main.scss
@@ -34,6 +34,14 @@ img {
 }
 
 .button--download-assets {
+  @include button--with-icon($medium-gray);
+
+  &::before {
+    background-image: url("../images/download-icon.svg");
+  }
+}
+
+.button--download-guide {
   @include button--with-icon;
 
   &::before {

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -38,6 +38,7 @@
       externally. Please reference this guide whenever you use these assets
       to ensure that they are used correctly.
     </p>
+    <a class="button--download-guide" href="assets/thoughtbot-brand-guidelines.pdf">Download Brand Guide</a>
     <a class="button--download-assets" href="assets/thoughtbot-assets-pack.zip">Download Assets Pack</a>
     <a class="button--github" href="https://github.com/thoughtbot/presskit">View on GitHub</a>
   </section>


### PR DESCRIPTION
The aim of this PR is to allow a user to download our brand guide from the press kit page. To do this I have added a button and pushed the brand guide file. 

__Before__
<img width="1079" alt="Screen Shot 2019-05-14 at 16 56 47" src="https://user-images.githubusercontent.com/12685877/57712985-823a1900-7669-11e9-836a-b30863df321f.png">

__After__
<img width="1077" alt="Screen Shot 2019-05-14 at 16 55 08" src="https://user-images.githubusercontent.com/12685877/57712998-8a925400-7669-11e9-97c9-ecb1941c28bc.png">
