### PR TITLE
Update colors to match new brand guidelines

### DIFF
--- a/source/assets/stylesheets/_main.scss
+++ b/source/assets/stylesheets/_main.scss
@@ -122,42 +122,9 @@ img {
 
   .primary-color-container {
     .primary-color {
-      @include size(200px, 300px);
+      @include size(260px, 300px);
       background: $thoughtbot-red;
       display: inline-block;
-    }
-
-    .opacity-shifts {
-      display: inline-block;
-      margin-left: -4px;
-    }
-
-    .opacity-shift-1,
-    .opacity-shift-2,
-    .opacity-shift-3,
-    .opacity-shift-4,
-    .opacity-shift-5 {
-      @include size(60px);
-    }
-
-    .opacity-shift-1 {
-      background: lighten($thoughtbot-red, 5);
-    }
-
-    .opacity-shift-2 {
-      background: lighten($thoughtbot-red, 10);
-    }
-
-    .opacity-shift-3 {
-      background: lighten($thoughtbot-red, 15);
-    }
-
-    .opacity-shift-4 {
-      background: lighten($thoughtbot-red, 20);
-    }
-
-    .opacity-shift-5 {
-      background: lighten($thoughtbot-red, 25);
     }
   }
 
@@ -175,33 +142,22 @@ img {
 
     .opacity-shift-1,
     .opacity-shift-2,
-    .opacity-shift-3,
-    .opacity-shift-4,
-    .opacity-shift-5 {
-      @include size(60px);
+    .opacity-shift-3 {
+      @include size(60px, 100px);
     }
 
     .opacity-shift-1 {
-      background: lighten($thoughtbot-gray, 5);
+      background: $thoughtbot-medium-gray;
     }
 
     .opacity-shift-2 {
-      background: lighten($thoughtbot-gray, 10);
+      background: $thoughtbot-light-gray;
     }
 
     .opacity-shift-3 {
-      background: lighten($thoughtbot-gray, 15);
-    }
-
-    .opacity-shift-4 {
-      background: lighten($thoughtbot-gray, 20);
-    }
-
-    .opacity-shift-5 {
-      background: lighten($thoughtbot-gray, 25);
+      background: $thoughtbot-ultralight-gray;
     }
   }
-
 }
 
 #typography {

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -36,6 +36,9 @@ $medium-gray: #9b9aa1;
 $light-gray: #b5b5c0;
 $thoughtbot-red: #e03131;
 $thoughtbot-gray: #29292c;
+$thoughtbot-medium-gray: #353539;
+$thoughtbot-light-gray: #4e4e53;
+$thoughtbot-ultralight-gray: #67676e;
 $light-green: #72ca11;
 
 // Font Colors

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -149,16 +149,18 @@
   <section id="colors">
     <h2>Colors</h2>
     <p>
-      The thoughtbot brand utilizes two main colors: “thoughtbot red” and
-      dark gray. These colors may be used with varying levels of opacity in
-      order to create “overlay” effects when layering colors and photography,
-      or creating transparency. Please use this reference guide to maintain
-      consistency of the brand.
+      The thoughtbot brand utilizes two main colors: our thoughtbot red,
+      that we affectionately call “Ralph” and dark gray, which we call
+      “Renee.” Ralph remains our main brand color and has multiple
+      applications from our logo, to action items, to backgrounds and
+      beyond. Renee may be used with varying levels of brightness to
+      allow it to be used for both type and background. Please view our
+      brand guide for more details on our use of color.
     </p>
     <div class="primary-color-container">
       <div class="primary-color"></div>
       <dl class="color-specs">
-        <dt>Primary Color</dt>
+        <dt>Ralph</dt>
         <dd><code>#e03131</code></dd>
         <dd><code>rgb(224, 49, 49)</code></dd>
         <dd><code>cmyk(0, 99, 91, 0)</code></dd>
@@ -173,7 +175,7 @@
         <div class="opacity-shift-3"></div>
       </div>
       <dl class="color-specs">
-        <dt>Secondary Color</dt>
+        <dt>Renee</dt>
         <dd><code>#29292c</code></dd>
         <dd><code>rgb(41, 41, 44)</code></dd>
         <dd><code>cmyk(7, 7, 0, 83)</code></dd>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -157,13 +157,6 @@
     </p>
     <div class="primary-color-container">
       <div class="primary-color"></div>
-      <div class="opacity-shifts">
-        <div class="opacity-shift-1"></div>
-        <div class="opacity-shift-2"></div>
-        <div class="opacity-shift-3"></div>
-        <div class="opacity-shift-4"></div>
-        <div class="opacity-shift-5"></div>
-      </div>
       <dl class="color-specs">
         <dt>Primary Color</dt>
         <dd><code>#e03131</code></dd>
@@ -178,8 +171,6 @@
         <div class="opacity-shift-1"></div>
         <div class="opacity-shift-2"></div>
         <div class="opacity-shift-3"></div>
-        <div class="opacity-shift-4"></div>
-        <div class="opacity-shift-5"></div>
       </div>
       <dl class="color-specs">
         <dt>Secondary Color</dt>


### PR DESCRIPTION
The aim of this pr is to update the colors on the press kit to match the colors inside our brand guideline document. The major change is the removal of alternate reds and a simplification of alternate dark colors. 

__Before__
<img width="1071" alt="presskit-color-og" src="https://user-images.githubusercontent.com/12685877/57792233-6781a600-7736-11e9-958e-805a555a13fe.png">

__After__
<img width="1076" alt="presskit-color-new" src="https://user-images.githubusercontent.com/12685877/57792242-6badc380-7736-11e9-9e1a-040ab4e99860.png">
