### PR TITLE
Add Accent Colors & Renee Color Details

### DIFF
--- a/source/assets/stylesheets/_main.scss
+++ b/source/assets/stylesheets/_main.scss
@@ -109,6 +109,10 @@ img {
   margin-bottom: 30px;
 }
 
+.color-container-shift {
+  margin-right: 100px;
+}
+
 .color-specs {
   font-size: $large-font-size;
   vertical-align: top;

--- a/source/assets/stylesheets/_main.scss
+++ b/source/assets/stylesheets/_main.scss
@@ -121,7 +121,7 @@ img {
 .color-specs {
   font-size: $large-font-size;
   vertical-align: top;
-  margin: 10px 0 0 0;
+  margin: 10px 0 0;
 
   dt {
     font-weight: $semibold-font-weight;
@@ -143,6 +143,7 @@ img {
   .renee-medium {
     color: $renee-medium;
   }
+
   .renee-ultralight{
     color: $renee-ultralight;
   }

--- a/source/assets/stylesheets/_main.scss
+++ b/source/assets/stylesheets/_main.scss
@@ -1,5 +1,5 @@
 body {
-  border-top: 8px solid $thoughtbot-red;
+  border-top: 8px solid $ralph;
   padding-top: 130px;
 }
 
@@ -19,11 +19,11 @@ nav a {
   &:focus,
   &:hover,
   &.active {
-    color: $thoughtbot-red;
+    color: $ralph;
 
     &::before {
       @include position(absolute, 21px null null -10px);
-      @include triangle("right", 7px, 10px, $thoughtbot-red);
+      @include triangle("right", 7px, 10px, $ralph);
       content: "";
     }
   }
@@ -81,7 +81,7 @@ img {
     text-transform: uppercase;
 
     &:first-of-type {
-      color: $thoughtbot-red;
+      color: $ralph;
     }
 
     &:nth-of-type(2n) {
@@ -99,65 +99,79 @@ img {
   }
 }
 
-#colors {
-  .primary-color-container,
-  .secondary-color-container {
-    margin-top: 50px;
+.color-title {
+  font-weight: 300;
+  margin-top: 40px;
+}
+
+.palette-container {
+  display: flex;
+  margin-bottom: 30px;
+}
+
+.color-specs {
+  font-size: $large-font-size;
+  vertical-align: top;
+  margin: 10px 0 0 0;
+
+  dt {
+    font-weight: $semibold-font-weight;
   }
 
-  .color-specs {
-    display: inline-block;
-    font-size: $large-font-size;
-    vertical-align: top;
-    margin: 0 0 0 22px;
-
-    dt {
-      font-weight: $semibold-font-weight;
-    }
-
-    dd {
-      margin-left: 0;
-    }
+  dd {
+    margin-left: 0;
   }
+}
 
-  .primary-color-container {
-    .primary-color {
-      @include size(260px, 300px);
-      background: $thoughtbot-red;
-      display: inline-block;
-    }
-  }
+.ralph-color-block {
+  @include size(320px, 180px);
+  background: $ralph;
+  display: inline-block;
+}
 
-  .secondary-color-container {
-    .secondary-color {
-      @include size(200px, 300px);
-      background: $thoughtbot-gray;
-      display: inline-block;
-    }
+.renee-color-block {
+  @include size(240px, 180px);
+  background: $thoughtbot-gray;
+  display: inline-block;
+}
 
-    .opacity-shifts {
-      display: inline-block;
-      margin-left: -4px;
-    }
+.jean-color-block {
+  @include size(180px, 180px);
+  background: $jean;
+  display: inline-block;
+}
 
-    .opacity-shift-1,
-    .opacity-shift-2,
-    .opacity-shift-3 {
-      @include size(60px, 100px);
-    }
+.alphie-color-block {
+  @include size(180px, 180px);
+  background: $alphie;
+  display: inline-block;
+}
 
-    .opacity-shift-1 {
-      background: $thoughtbot-medium-gray;
-    }
+.opacity-shifts {
+  display: inline-block;
+  margin-left: -4px;
+}
 
-    .opacity-shift-2 {
-      background: $thoughtbot-light-gray;
-    }
+.opacity-shift-1,
+.opacity-shift-2,
+.opacity-shift-3 {
+  @include size(80px, 60px);
+}
 
-    .opacity-shift-3 {
-      background: $thoughtbot-ultralight-gray;
-    }
-  }
+.opacity-shift-1 {
+  background: $thoughtbot-medium-gray;
+}
+
+.opacity-shift-2 {
+  background: $thoughtbot-light-gray;
+}
+
+.opacity-shift-3 {
+  background: $thoughtbot-ultralight-gray;
+}
+
+.uppercase {
+  text-transform: uppercase;
 }
 
 #typography {
@@ -175,9 +189,9 @@ img {
     letter-spacing: 5px;
   }
 
-  .uppercase {
-    text-transform: uppercase;
-  }
+  // .uppercase {
+  //   text-transform: uppercase;
+  // }
 
   .regular-typeface {
     h3,

--- a/source/assets/stylesheets/_main.scss
+++ b/source/assets/stylesheets/_main.scss
@@ -113,6 +113,11 @@ img {
   margin-right: 100px;
 }
 
+.renee-details-container {
+  display: flex;
+  justify-content: space-between;
+}
+
 .color-specs {
   font-size: $large-font-size;
   vertical-align: top;
@@ -127,6 +132,22 @@ img {
   }
 }
 
+.color-specs-names {
+  font-size: $base-font-size;
+  text-align: right;
+
+  .renee-light {
+    color: $renee-light;
+  }
+
+  .renee-medium {
+    color: $renee-medium;
+  }
+  .renee-ultralight{
+    color: $renee-ultralight;
+  }
+}
+
 .ralph-color-block {
   @include size(320px, 180px);
   background: $ralph;
@@ -135,7 +156,7 @@ img {
 
 .renee-color-block {
   @include size(240px, 180px);
-  background: $thoughtbot-gray;
+  background: $renee;
   display: inline-block;
 }
 
@@ -160,18 +181,27 @@ img {
 .opacity-shift-2,
 .opacity-shift-3 {
   @include size(80px, 60px);
+  position: relative;
 }
 
 .opacity-shift-1 {
-  background: $thoughtbot-medium-gray;
+  background: $renee-medium;
 }
 
 .opacity-shift-2 {
-  background: $thoughtbot-light-gray;
+  background: $renee-light;
 }
 
 .opacity-shift-3 {
-  background: $thoughtbot-ultralight-gray;
+  background: $renee-ultralight;
+}
+
+.opacity-shift-text {
+  bottom: 0;
+  color: $white;
+  font-size: $base-font-size;
+  margin: 0 0 5px 10px;
+  position: absolute;
 }
 
 .uppercase {
@@ -192,10 +222,6 @@ img {
   .lowercase {
     letter-spacing: 5px;
   }
-
-  // .uppercase {
-  //   text-transform: uppercase;
-  // }
 
   .regular-typeface {
     h3,

--- a/source/assets/stylesheets/base/_typography.scss
+++ b/source/assets/stylesheets/base/_typography.scss
@@ -21,7 +21,7 @@ h4 {
 
 h1 {
   font-size: $base-font-size * 3;
-  color: $thoughtbot-red;
+  color: $ralph;
 }
 
 h2 {

--- a/source/assets/stylesheets/base/_typography.scss
+++ b/source/assets/stylesheets/base/_typography.scss
@@ -20,8 +20,8 @@ h4 {
 }
 
 h1 {
-  font-size: $base-font-size * 3;
   color: $ralph;
+  font-size: $base-font-size * 3;
 }
 
 h2 {

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -30,7 +30,7 @@ $base-spacing: $base-line-height * 1em;
 $small-spacing: $base-spacing / 2;
 
 // Colors
-$white: #ffffff;
+$white: #fff;
 $blue: #477dca;
 $dark-gray: #3d3e44;
 $medium-gray: #9b9aa1;

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -30,23 +30,24 @@ $base-spacing: $base-line-height * 1em;
 $small-spacing: $base-spacing / 2;
 
 // Colors
+$white: #ffffff;
 $blue: #477dca;
 $dark-gray: #3d3e44;
 $medium-gray: #9b9aa1;
 $light-gray: #b5b5c0;
 $ralph: #e03131;
-$thoughtbot-gray: #29292c;
-$thoughtbot-medium-gray: #353539;
-$thoughtbot-light-gray: #4e4e53;
-$thoughtbot-ultralight-gray: #67676e;
+$renee: #29292c;
+$renee-medium: #353539;
+$renee-light: #4e4e53;
+$renee-ultralight: #67676e;
 $jean: #0b758c;
 $alphie: #f3adad;
 $light-green: #72ca11;
 
 // Font Colors
-$base-font-color: tint($thoughtbot-gray, 13%);
+$base-font-color: tint($renee, 13%);
 $action-color: $ralph;
-$heading-font-color: $thoughtbot-gray;
+$heading-font-color: $renee;
 
 // Border
 $base-border-color: $light-gray;

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -34,16 +34,18 @@ $blue: #477dca;
 $dark-gray: #3d3e44;
 $medium-gray: #9b9aa1;
 $light-gray: #b5b5c0;
-$thoughtbot-red: #e03131;
+$ralph: #e03131;
 $thoughtbot-gray: #29292c;
 $thoughtbot-medium-gray: #353539;
 $thoughtbot-light-gray: #4e4e53;
 $thoughtbot-ultralight-gray: #67676e;
+$jean: #0b758c;
+$alphie: #f3adad;
 $light-green: #72ca11;
 
 // Font Colors
 $base-font-color: tint($thoughtbot-gray, 13%);
-$action-color: $thoughtbot-red;
+$action-color: $ralph;
 $heading-font-color: $thoughtbot-gray;
 
 // Border

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -154,7 +154,7 @@
       “Renee.” Ralph remains our main brand color and has multiple
       applications from our logo, to action items, to backgrounds and
       beyond. Renee may be used with varying levels of brightness to
-      allow it to be used for both type and background. Our Accent colors
+      allow it to be used for both type and background. Our accent colors
       play supportive roles in treatments such as text underlines or
       indicating active states on the web. Please view our brand guide
       for more details on our use of color.
@@ -174,17 +174,30 @@
       <div class="color-container">
         <div class="renee-color-block"></div>
         <div class="opacity-shifts">
-          <div class="opacity-shift-1"></div>
-          <div class="opacity-shift-2"></div>
-          <div class="opacity-shift-3"></div>
+          <div class="opacity-shift-1">
+            <p class="opacity-shift-text">#353539</p>
+          </div>
+          <div class="opacity-shift-2">
+            <p class="opacity-shift-text">#4e4e53</p>
+          </div>
+          <div class="opacity-shift-3">
+            <p class="opacity-shift-text">#67676e</p>
+          </div>
         </div>
-        <dl class="color-specs">
-          <dt>Renee</dt>
-          <dd>#29292c</dd>
-          <dd>rgb(41, 41, 44)</dd>
-          <dd>cmyk(7, 7, 0, 83)</dd>
-          <dd>Pantone® P 98-16u*</dd>
-        </dl>
+        <div class="renee-details-container">
+          <dl class="color-specs">
+            <dt>Renee</dt>
+            <dd>#29292c</dd>
+            <dd>rgb(41, 41, 44)</dd>
+            <dd>cmyk(7, 7, 0, 83)</dd>
+            <dd>Pantone® P 98-16u*</dd>
+          </dl>
+          <dl class="color-specs color-specs-names">
+            <dd class="renee-medium">Renee-Medium</dd>
+            <dd class="renee-light">Renee-Light</dd>
+            <dd class="renee-ultralight">Renee-Ultralight</dd>
+          </dl>
+        </div>
       </div>
     </div>
     <h3 class="color-title uppercase">Accent Colors</h3>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -157,30 +157,56 @@
       allow it to be used for both type and background. Please view our
       brand guide for more details on our use of color.
     </p>
-    <div class="primary-color-container">
-      <div class="primary-color"></div>
-      <dl class="color-specs">
-        <dt>Ralph</dt>
-        <dd><code>#e03131</code></dd>
-        <dd><code>rgb(224, 49, 49)</code></dd>
-        <dd><code>cmyk(0, 99, 91, 0)</code></dd>
-        <dd>Pantone® P 48-8u*</dd>
-      </dl>
-    </div>
-    <div class="secondary-color-container">
-      <div class="secondary-color"></div>
-      <div class="opacity-shifts">
-        <div class="opacity-shift-1"></div>
-        <div class="opacity-shift-2"></div>
-        <div class="opacity-shift-3"></div>
+    <h3 class="color-title uppercase">Primary Colors</h3>
+    <div class="palette-container">
+      <div class="color-container">
+        <div class="ralph-color-block"></div>
+        <dl class="color-specs">
+          <dt>Ralph</dt>
+          <dd>#e03131</dd>
+          <dd>rgb(224, 49, 49)</dd>
+          <dd>cmyk(0, 99, 91, 0)</dd>
+          <dd>Pantone® P 48-8u*</dd>
+        </dl>
       </div>
-      <dl class="color-specs">
-        <dt>Renee</dt>
-        <dd><code>#29292c</code></dd>
-        <dd><code>rgb(41, 41, 44)</code></dd>
-        <dd><code>cmyk(7, 7, 0, 83)</code></dd>
-        <dd>Pantone® P 98-16u*</dd>
-      </dl>
+      <div class="color-container">
+        <div class="renee-color-block"></div>
+        <div class="opacity-shifts">
+          <div class="opacity-shift-1"></div>
+          <div class="opacity-shift-2"></div>
+          <div class="opacity-shift-3"></div>
+        </div>
+        <dl class="color-specs">
+          <dt>Renee</dt>
+          <dd>#29292c</dd>
+          <dd>rgb(41, 41, 44)</dd>
+          <dd>cmyk(7, 7, 0, 83)</dd>
+          <dd>Pantone® P 98-16u*</dd>
+        </dl>
+      </div>
+    </div>
+    <h3 class="color-title uppercase">Accent Colors</h3>
+    <div class="palette-container">
+      <div class="color-container">
+        <div class="jean-color-block"></div>
+        <dl class="color-specs">
+          <dt>Jean</dt>
+          <dd>#0b758c</dd>
+          <dd>rgb(11, 17, 140)</dd>
+          <dd>cmyk(51, 9, 0, 45)</dd>
+          <dd>Pantone® P 119-8u*</dd>
+        </dl>
+      </div>
+      <div class="color-container">
+        <div class="alphie-color-block"></div>
+        <dl class="color-specs">
+          <dt>Alphie</dt>
+          <dd>#f3adad</dd>
+          <dd>rgb(243, 173, 173)</dd>
+          <dd>cmyk(0, 29, 29, 5)</dd>
+          <dd>Pantone® P 65-3u*</dd>
+        </dl>
+      </div>
     </div>
     <p>
       <small>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -154,12 +154,14 @@
       “Renee.” Ralph remains our main brand color and has multiple
       applications from our logo, to action items, to backgrounds and
       beyond. Renee may be used with varying levels of brightness to
-      allow it to be used for both type and background. Please view our
-      brand guide for more details on our use of color.
+      allow it to be used for both type and background. Our Accent colors
+      play supportive roles in treatments such as text underlines or
+      indicating active states on the web. Please view our brand guide
+      for more details on our use of color.
     </p>
     <h3 class="color-title uppercase">Primary Colors</h3>
     <div class="palette-container">
-      <div class="color-container">
+      <div class="color-container-shift">
         <div class="ralph-color-block"></div>
         <dl class="color-specs">
           <dt>Ralph</dt>
@@ -187,7 +189,7 @@
     </div>
     <h3 class="color-title uppercase">Accent Colors</h3>
     <div class="palette-container">
-      <div class="color-container">
+      <div class="color-container-shift">
         <div class="jean-color-block"></div>
         <dl class="color-specs">
           <dt>Jean</dt>


### PR DESCRIPTION
The aim of this PR is to add the accent colors to the press kit along with add the details about the alternative Renee color values (Renee-medium, Renee-light, Renee-ultralight). 

__Initial__

<img width="1442" alt="presskit-color-initial" src="https://user-images.githubusercontent.com/12685877/58954360-e182d900-8790-11e9-98a2-d1ea4fac1c1f.png">

__Updated Palette__

<img width="1441" alt="presskit-color-new" src="https://user-images.githubusercontent.com/12685877/58954366-e5aef680-8790-11e9-9cc2-ee1402934582.png">
