### PR TITLE
Update redirect to new static logo url for READMEs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
   from = "/images/thoughtbot-logo-for-readmes.svg"
-  to = "https://thoughtbot.com/brand_assets/93:44.svg"
+  to = "https://thoughtbot.com/thoughtbot-logo-for-readmes.svg"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION
We no longer have the brand assets server like we did before.